### PR TITLE
Fix hiding control bar on small screens

### DIFF
--- a/css/leanorama.controlbar.css
+++ b/css/leanorama.controlbar.css
@@ -20,7 +20,7 @@
     position:   fixed;
     bottom:     0;
     left:       0;
-    
+    white-space: nowrap;
     /* prevent text selection of buttons */
     -webkit-touch-callout: none;
     -webkit-user-select: none;


### PR DESCRIPTION
If the screen is too small to show the complete control bar, the
control bar gets wrapped around and hiding the control bar doesn’t work
as expected
